### PR TITLE
Reduce chances of multiplication overflow

### DIFF
--- a/src/LercLib/Lerc1Decode/CntZImage.cpp
+++ b/src/LercLib/Lerc1Decode/CntZImage.cpp
@@ -48,7 +48,7 @@ bool CntZImage::resizeFill0(int width, int height)
   if (!resize(width, height))
     return false;
 
-  memset(getData(), 0, width * height * sizeof(CntZ));
+  memset(getData(), 0, (size_t)width * height * sizeof(CntZ));
   return true;
 }
 
@@ -164,7 +164,7 @@ bool CntZImage::read(const Byte** ppByte, double maxZError, bool onlyHeader, boo
         // decompress to bit mask
         BitMask bitMask(width_, height_);
         RLE rle;
-        if (!rle.decompress(bArr, width_ * height_ * 2, (Byte*)bitMask.Bits(), bitMask.Size()))
+        if (!rle.decompress(bArr, (size_t)width_ * height_ * 2, (Byte*)bitMask.Bits(), bitMask.Size()))
           return false;
 
         CntZ* dstPtr = getData();

--- a/src/LercLib/Lerc1Decode/TImage.hpp
+++ b/src/LercLib/Lerc1Decode/TImage.hpp
@@ -88,7 +88,7 @@ bool TImage< Element >::resize(int width, int height)
   width_ = 0;
   height_ = 0;
 
-  data_ = (Element*)malloc(width * height * sizeof(Element));
+  data_ = (Element*)malloc((size_t)width * height * sizeof(Element));
   if (!data_)
     return false;
 

--- a/src/LercLib/Lerc_c_api_impl.cpp
+++ b/src/LercLib/Lerc_c_api_impl.cpp
@@ -284,7 +284,7 @@ lerc_status lerc_decodeToDouble_4D(const unsigned char* pLercBlob, unsigned int 
   {
     // use the buffer passed for in place decode and convert
     int sizeofDt[] = { 1, 1, 2, 2, 4, 4, 4, 8 };
-    size_t nDataValues = nDepth * nCols * nRows * nBands;
+    size_t nDataValues = (size_t)nDepth * nCols * nRows * nBands;
     void* ptrDec = (Byte*)pData + nDataValues * (sizeof(double) - sizeofDt[dt]);
 
     if ((errCode = Lerc::Decode(pLercBlob, blobSize, nMasks, pValidBytes,


### PR DESCRIPTION
Runs afoul of the CodeQL rule cpp/integer-multiplication-cast-to-long

[jira] TF-5293